### PR TITLE
Use more appropriate dependency link in comment

### DIFF
--- a/src/SparkFun_Flying_Jalapeno_Arduino_Library.cpp
+++ b/src/SparkFun_Flying_Jalapeno_Arduino_Library.cpp
@@ -6,7 +6,7 @@
 
 #include "SparkFun_Flying_Jalapeno_Arduino_Library.h"
 
-#include <CapacitiveSensor.h> //Click here to get the library: http://librarymanager/All#CapacitiveSensor_Arduino
+#include <CapacitiveSensor.h> //https://github.com/PaulStoffregen/CapacitiveSensor
 CapacitiveSensor button1 = CapacitiveSensor(47, 45); //Wired to pins 47/45 on nearly every jig
 CapacitiveSensor button2 = CapacitiveSensor(31, 46); //Wired to pins 31/46 on nearly every jig
 


### PR DESCRIPTION
The `http://librarymanager` links are only clickable in sketches. They are not clickable in the Arduino IDE's console. So use of the `http://librarymanager` link in the library source is not terribly helpful.